### PR TITLE
Create Python Equivalent To Actions Command

### DIFF
--- a/package/dev_tools/actions.py
+++ b/package/dev_tools/actions.py
@@ -1,0 +1,17 @@
+### © Copyright 2024 Frankie Homewood <F.Homewood@outlook.com>
+# A command to manage existing actions created in notes files.
+
+import click
+import shutil
+import os
+import re
+
+from datetime import datetime
+from pathlib import Path
+
+@click.command()
+def cli():
+    title_notes()
+
+def actions():
+    pass

--- a/package/dev_tools/actions.py
+++ b/package/dev_tools/actions.py
@@ -2,12 +2,10 @@
 # A command to manage existing actions created in notes files.
 
 import click
-import shutil
 import os
 import re
 import json
 
-from datetime import datetime
 from pathlib import Path
 
 @click.group(invoke_without_command=True)
@@ -16,13 +14,36 @@ def cli(ctx):
     if not ctx.invoked_subcommand:
         actions()
 
+
 @cli.command()
 @click.argument(
-    'ticket_pattern',
+    'close_pattern',
     type=str
 )
-def close(ticket_pattern):
-    print(ticket_pattern)
+def close(close_pattern):
+    dev_tools_dir = Path.home() / '.dev-tools'
+    notes_dir = Path.home() / "Notes/"
+
+    is_successful = False
+    error_message = ''
+
+    try:
+        actions_file_path = dev_tools_dir / 'dot-files'/ '.dtactions'
+        actions_file = initialise_actions_file(actions_file_path)
+        for action in actions_file['active']:
+            print(f'current_action={action}')
+        matches = [i for i in actions_file['active'] if re.search(close_pattern, i)]
+        print(f'{matches=}')
+        is_successful = True
+    except Exception as e:
+        display("There was a failure.", "cyan")
+        exception_message = getattr(e, "message", repr(e))
+    if not is_successful:
+        error_message += exception_message
+        if not error_message:
+            error_message = "An unknown error occurred"
+        display(error_message, "cyan")
+
 
 def actions():
     dev_tools_dir = Path.home() / '.dev-tools'
@@ -32,16 +53,7 @@ def actions():
     error_message = ''
     try:
         actions_file_path = dev_tools_dir / 'dot-files'/ '.dtactions'
-        os.makedirs(actions_file_path.parent, exist_ok=True)
-        if not actions_file_path.is_file():
-            with open(actions_file_path, 'w') as file:
-                file.write('{}')
-        with open(actions_file_path, 'r') as file:
-            actions_file = json.load(file)
-        if not hasattr(actions_file, 'closed'):
-            actions_file['closed'] = list()
-        if not hasattr(actions_file, 'active'):
-            actions_file['active'] = list()
+        actions_file = initialise_actions_file(actions_file_path)
         sub_files = notes_dir.glob('**/*.md')
         all_actions = get_all_actions(sub_files)
         actions_file['active'] = list(all_actions.difference(set(actions_file['closed'])))
@@ -53,22 +65,36 @@ def actions():
     except Exception as e:
         display("There was a failure.", "cyan")
         exception_message = getattr(e, "message", repr(e))
-    if is_successful:
-        display("Done!", "bright_green")
-    else:
+    if not is_successful:
         error_message += exception_message
         if not error_message:
             error_message = "An unknown error occurred"
         display(error_message, "cyan")
 
+def initialise_actions_file(file_path):
+    os.makedirs(file_path.parent, exist_ok=True)
+    if not file_path.is_file():
+        with open(file_path, 'w') as file:
+            file.write('{}')
+    with open(file_path, 'r') as file:
+        actions_file = json.load(file)
+    if not actions_file.get('closed'):
+        actions_file['closed'] = list()
+    if not actions_file.get('active'):
+        actions_file['active'] = list()
+    return actions_file
+
+
 def get_all_actions(files):
     return set(get_action_generator(files))
+
 
 def get_action_generator(files):
     for file in files:
         file_actions = get_actions(file)
         for action in file_actions:
             yield action
+
 
 def get_actions(file):
     ts_regex = r'^[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}-[0-9]{2}'
@@ -89,6 +115,7 @@ def get_actions(file):
         ]
     actions = [f"{timestamp} | {action}" for action in actions]
     return actions
+
 
 def display(message, color="bright_cyan"):
     click.echo(click.style(message, fg=color))

--- a/package/dev_tools/actions.py
+++ b/package/dev_tools/actions.py
@@ -10,9 +10,19 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-@click.command()
-def cli():
-    actions()
+@click.group(invoke_without_command=True)
+@click.pass_context
+def cli(ctx):
+    if not ctx.invoked_subcommand:
+        actions()
+
+@cli.command()
+@click.argument(
+    'ticket_pattern',
+    type=str
+)
+def close(ticket_pattern):
+    print(ticket_pattern)
 
 def actions():
     dev_tools_dir = Path.home() / '.dev-tools'
@@ -33,12 +43,12 @@ def actions():
         if not hasattr(actions_file, 'active'):
             actions_file['active'] = list()
         sub_files = notes_dir.glob('**/*.md')
-        all_actions = pull_actions_from_files(sub_files)
-        print(list(all_actions))
-
-
-
-        print(actions_file)
+        all_actions = get_all_actions(sub_files)
+        actions_file['active'] = list(all_actions.difference(set(actions_file['closed'])))
+        with open(actions_file_path, 'w') as file:
+            json.dump(actions_file, file)
+        for action in actions_file.get('active', list()):
+            display(action)
         is_successful = True
     except Exception as e:
         display("There was a failure.", "cyan")
@@ -51,12 +61,34 @@ def actions():
             error_message = "An unknown error occurred"
         display(error_message, "cyan")
 
-def pull_actions_from_files(files):
+def get_all_actions(files):
+    return set(get_action_generator(files))
+
+def get_action_generator(files):
     for file in files:
-        yield get_actions(file)
+        file_actions = get_actions(file)
+        for action in file_actions:
+            yield action
 
 def get_actions(file):
-    return file.stem, 2
+    ts_regex = r'^[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}-[0-9]{2}'
+    if not re.match(ts_regex, file.stem):
+        return list()
+    with open(file, 'r') as file_reader:
+        file_contents = ''.join(file_reader.readlines())
+    timestamp = re.match(f"({ts_regex})", file.stem).group(1)
+    actions_regex = r'(?<=### Actions\n)(.*\n)*(?=\n### Tags)'
+    actions = re.search(actions_regex, file_contents)
+    if not actions:
+        return list()
+    actions = actions.group(1)
+    actions = [
+        re.match('- (.+)', action_line).group(1)
+        for action_line in actions.split('\n')
+        if re.match('- (.+)', action_line)
+        ]
+    actions = [f"{timestamp} | {action}" for action in actions]
+    return actions
 
 def display(message, color="bright_cyan"):
     click.echo(click.style(message, fg=color))

--- a/package/dev_tools/actions.py
+++ b/package/dev_tools/actions.py
@@ -5,13 +5,40 @@ import click
 import shutil
 import os
 import re
+import json
 
 from datetime import datetime
 from pathlib import Path
 
 @click.command()
 def cli():
-    title_notes()
+    actions()
 
 def actions():
-    pass
+    dev_tools_dir = Path.home() / '.dev-tools'
+    notes_dir = Path.home() / "Notes/"
+
+    is_successful = False
+    error_message = ''
+    try:
+        actions_file_path = dev_tools_dir / 'dot-files'/ '.dtactions'
+        os.makedirs(actions_file_path.parent, exist_ok=True)
+        if not actions_file_path.is_file():
+            with open(actions_file_path, 'w') as file:
+                file.write('{}')
+        actions_file = json.load(actions_file_path)
+        is_successful = True
+    except Exception as e:
+        display("There was a failure.", "cyan")
+        exception_message = getattr(e, "message", repr(e))
+    if is_successful:
+        display("Done!", "bright_green")
+    else:
+        error_message += exception_message
+        if not error_message:
+            error_message = "An unknown error occurred"
+        display(error_message, "cyan")
+
+
+def display(message, color="bright_cyan"):
+    click.echo(click.style(message, fg=color))

--- a/package/dev_tools/actions.py
+++ b/package/dev_tools/actions.py
@@ -26,7 +26,19 @@ def actions():
         if not actions_file_path.is_file():
             with open(actions_file_path, 'w') as file:
                 file.write('{}')
-        actions_file = json.load(actions_file_path)
+        with open(actions_file_path, 'r') as file:
+            actions_file = json.load(file)
+        if not hasattr(actions_file, 'closed'):
+            actions_file['closed'] = list()
+        if not hasattr(actions_file, 'active'):
+            actions_file['active'] = list()
+        sub_files = notes_dir.glob('**/*.md')
+        all_actions = pull_actions_from_files(sub_files)
+        print(list(all_actions))
+
+
+
+        print(actions_file)
         is_successful = True
     except Exception as e:
         display("There was a failure.", "cyan")
@@ -39,6 +51,12 @@ def actions():
             error_message = "An unknown error occurred"
         display(error_message, "cyan")
 
+def pull_actions_from_files(files):
+    for file in files:
+        yield get_actions(file)
+
+def get_actions(file):
+    return file.stem, 2
 
 def display(message, color="bright_cyan"):
     click.echo(click.style(message, fg=color))

--- a/package/dev_tools/meeting.py
+++ b/package/dev_tools/meeting.py
@@ -351,7 +351,6 @@ def new_daily():
     shutil.rmtree(temp_dir)
     if is_successful:
         os.system(
-        # print(
             f'code "{today_dir.absolute()}" "{today_dir / date.strftime("%Y-%m-%d_%H-%M-%S - Daily Notes.md")}"'
         )
         display("Done!", "bright_green")

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
 ]
 
 [project.scripts]
-# actions = "dev_tools.actions:cli"
+actions = "dev_tools.actions:cli"
 # delenv = "dev_tools.delenv:cli"
 # dev-tools = "dev_tools.dev-tools:cli"
 meeting = "dev_tools.meeting:cli"


### PR DESCRIPTION
## [Create Python Equivalent To Actions Command](https://github.com/FHomewood/dev-tools/issues/30)
Adding a translation of the logic of the meeting command in `actions.ps1` into a python script will allow the functionality to be independent of the syntax of any given operating system. Enabling more development specific tools in future.

### Adds
- Python `actions` cli command.
<!--
- `title.py` command changes notes names according to the same rules as `title-notes.ps1`.
-->

<!-- 
### Changes
- Python `title-notes` command renamed to `title` for compatibility. 
-->