### PR TITLE
Fix Duplicate Tags Header in KIT Notes

### DIFF
--- a/package/dev_tools/meeting.py
+++ b/package/dev_tools/meeting.py
@@ -159,7 +159,7 @@ def new_kit():
         display("  - Extracting information from last meeting...")
         with open(most_recent_kit, "r") as file:
             data = "".join(file.readlines())
-        regex = "^(?:(?:.*\n)*)### Check-in\n((?:.*\n)*)\n## Goals\n((?:.*\n)*)\n## Actions\n(?:(?:.*\n)*)\n### Actions\n((?:.*\n*)*)"
+        regex = "^(?:(?:.*\n)*)### Check-in\n((?:.*\n)*)\n## Goals\n((?:.*\n)*)\n## Actions\n(?:(?:.*\n)*)\n### Actions\n((?:.*\n*)*)\n### Tags"
         match = re.match(regex, data)
 
         # Define values to replace

--- a/scripts/meeting.ps1
+++ b/scripts/meeting.ps1
@@ -124,7 +124,7 @@ function New-KIT {
         # Find information from the most recent kit 
         # And extract it into the new one
         Write-Host "  - Extracting information from last meeting..." -ForegroundColor Cyan
-        $regex = "### Check-in`n((?:.*`n)*)`n## Goals`n((?:.*`n)*)`n## Actions`n(?:(?:.*`n)*)`n### Actions`n((?:.*`n*)*)"
+        $regex = "### Check-in`n((?:.*`n)*)`n## Goals`n((?:.*`n)*)`n## Actions`n(?:(?:.*`n)*)`n### Actions`n((?:.*`n*)*)`n### Tags"
         $data =  [string]::Join("`n", (Get-Content -Path $most_recent_kit.FullName))
         $match = $data | Select-String -Pattern $regex
 


### PR DESCRIPTION
## [Fix Duplicate Tags Header in KIT Notes](https://github.com/FHomewood/dev-tools/issues/23)
There is currently a bug with how KIT notes templates are generated, giving two `## Tags` sections, likely due to a issue with the regex captures not being accounted for when the `actions` command was implemented.

### Fixes
- Missing `### Tags` identifier in the KIT extraction regex pattern.