### PR TITLE
Initialize git repo with new team member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - Meeting command now has generic `note` template.
+- New team member directories initialize a local git repository.
 
 ### Changed
 - Refactored meeting command into smaller functions.

--- a/package/dev_tools/meeting.py
+++ b/package/dev_tools/meeting.py
@@ -148,6 +148,11 @@ def new_team_member(kit_dir, team_member=None):
 
     clone_dir_contents(from_dir=TEMP_DIR, to_dir=team_member)
 
+    progress("Initializing git repository")
+    from git import Repo
+
+    Repo.init(team_member)
+
     most_recent_kit = list(
         (kit_dir / team_member).glob("*")
     )  ## TODO: Change glob argument to only target KIT files

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -12,7 +12,8 @@ license = { file = "LICENSE" }
 requires-python = ">=3.11"
 
 dependencies = [
-    'click'
+    'click',
+    'GitPython'
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## [Initialize git repo with new team member](https://github.com/FHomewood/dev-tools/issues/45)
Add a step to the Keep In Touch logic that includes the creation of a local git repository when creating a new team member.

### Adds
- New team member directories initialize a local git repository.
<!-- 
### Changes
-
### Fixes
-
### Removes
-
### Security Updates
-
### Testing
-
-->